### PR TITLE
Replace Config::getInstance->appRoot() by $this->appRoot()

### DIFF
--- a/src/CodeGenerator/CodeGeneratorConfig.php
+++ b/src/CodeGenerator/CodeGeneratorConfig.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gacela\CodeGenerator;
 
 use Gacela\Framework\AbstractConfig;
-use Gacela\Framework\Config;
 use JsonException;
 use LogicException;
 
@@ -38,7 +37,7 @@ final class CodeGeneratorConfig extends AbstractConfig
      */
     public function getComposerJsonContentAsArray(): array
     {
-        $filename = Config::getInstance()->getAppRootDir() . '/composer.json';
+        $filename = $this->getAppRootDir() . '/composer.json';
         if (!file_exists($filename)) {
             throw new LogicException('composer.json file not found but it is required');
         }


### PR DESCRIPTION
## 📚 Description

We were using on `Gacela\CodeGenerator/CodeGeneratorConfig` the old way to get the application root directory through the `Config` class, which in fact was not working because the namespace of the `Config` class was changed recently.

This PR solves using the proper `AbstractConfig` method such as `$this->getAppRootDir()` one instead.

Everything is working fine now 😄 
